### PR TITLE
Issue #14 - Adding class with type to rmd-data-item template.

### DIFF
--- a/templates/psul-rmd-item.html.twig
+++ b/templates/psul-rmd-item.html.twig
@@ -1,5 +1,6 @@
 {% set classes = [
   'psul-data-content',
+  'psul-data-content--' ~ type|clean_class,
 ] %}
 
 {% if content %}


### PR DESCRIPTION
Adding type class.  In the example below this is `psul-data-content--education-history`

<img width="1031" alt="Screenshot 2025-02-11 at 2 32 58 PM" src="https://github.com/user-attachments/assets/10f60d75-3b51-4e45-b747-4f2460c94191" />
