### PR TITLE
Issue #19 - not throwing errors if response is 404 with message that …

### DIFF
--- a/src/RmdDataFetcher.php
+++ b/src/RmdDataFetcher.php
@@ -133,6 +133,14 @@ class RmdDataFetcher implements RmdDataFetcherInterface {
       $this->data = $data;
     }
     catch (GuzzleException | \Exception $e) {
+      if ($e->getCode() === 404 && str_contains($e->getMessage(), 'User not found')) {
+        $this->cacheData->set(
+          $cache_id,
+          ['data' => []],
+          time() + $config->get('cache_ttl') ?? 172800
+        );
+        return;
+      }
       $this->data = ['data' => []];
       $this->getLogger('psul_rmd_drupal_integration')->error($e->getMessage());
     }


### PR DESCRIPTION
…contains "User not found"

If RMD returns a  "User not found" 404 message then treat that as a valid response. So cache the response and don't log an error.  