### PR TITLE
18 investigate make rmd data caching more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PSU Libraries Researcher Metadata Database (RMD) Integration
 
-Integrate a Drupal site with the PSU Libraries [Researcher Metadata Database](https://metadata.libraries.psu.edu/). The intent of this module is to allow data to be pulled from the RMD API and expose that data to Drupal.
+Integrate a Drupal site with the PSU Libraries [Researcher Metadata Database](https://metadata.libraries.psu.edu/) (RMD). The intent of this module is to allow data to be pulled from the RMD API and expose that data to Drupal.
 
 Currently, only the User profile API endpoint has been implemented.  Other endpoints will require an API key to use.
 
@@ -42,4 +42,26 @@ $rmd_data = $rmd_data_fetcher->getProfileData($username);
 // Get specific attribute.
 $orcid_url = $rmd_data_fetcher->getProfileData($username, 'orcid_identifier');
 $bio = $rmd_data_fetcher->getProfileData($username, 'bio');
+```
+
+### Data Caching
+This modules use the Permanent Cache Bin module aggressively cache the data
+from RMD.
+
+You can clear the RMD cached data a couple of ways.  *Note:* The rmd_data cache will be cleared
+for individual nodes upon save.
+
+**Drush**
+
+```bash
+drush pcbf rmd_data
+```
+**UI**
+
+Go to `/admin/config/development/performance` and click the "Clear permament cache for rmd_data" button.
+
+**Programmatically**
+
+```php
+\Drupal::service('cache.rmd_data')->deleteAllPermanent();
 ```

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,8 @@
             "email": "msh6004@psu.edu"
         }
     ],
-    "require": {},
-    "license": "GPL-2.0-or-later"
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "drupal/pcb": "^4.0"
+    }
 }

--- a/psul_rmd_drupal_integration.info.yml
+++ b/psul_rmd_drupal_integration.info.yml
@@ -3,3 +3,5 @@ type: module
 description: 'Drupal module to add PSU branding SDC.'
 package: 'PSU Libraries'
 core_version_requirement: ^10 || ^11
+dependencies:
+  - pcb:pcb

--- a/psul_rmd_drupal_integration.module
+++ b/psul_rmd_drupal_integration.module
@@ -5,6 +5,8 @@
  * Contains hook implementations for the psul_rmd_drupal_integration module.
  */
 
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\psul_rmd_drupal_integration\RmdDataFetcherInterface;
 
 /**
@@ -80,37 +82,32 @@ function psul_rmd_drupal_integration_entity_extra_field_info(): array {
 }
 
 /**
+ * Implements hook_entity_presave().
+ */
+function psul_rmd_drupal_integration_entity_presave(EntityInterface $entity) {
+  $username = _psul_rmd_drupal_integration_should_have_rmd_data($entity);
+  if ($username) {
+    $cache_id = 'psul_rmd_data:profile:' . $entity->label();
+    \Drupal::service('cache.rmd_data')->delete($cache_id);
+  }
+}
+
+/**
  * Implements hook_preprocess_node().
  */
 function psul_rmd_drupal_integration_preprocess_node(array &$variables) {
-  $config = \Drupal::config('psul_rmd_drupal_integration.settings');
-  $content_type = $config->get('attached_content_type');
-  $username_field = $config->get('attached_username_field');
-
-  // Skip if the content type or username field are not set.
-  if (!$content_type || !$username_field) {
-    return;
-  }
-
-  // Skip if the current node is not the correct content type or does not have
-  // the username field.
-  if ($variables['node']->getType() !== $content_type || !$variables['node']->hasField($username_field)) {
-    return;
-  }
-
-  // Get the username from the node and return if it is not found.
-  $username = $variables['node']->get($username_field)->getString();
+  $username = _psul_rmd_drupal_integration_should_have_rmd_data($variables['node']);
   if (!$username) {
     return;
   }
 
   // Check if any rmd_ fields are displayed for the current view mode.
   $view_mode = $variables['view_mode'];
-  $display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $content_type . '.' . $view_mode);
+  $display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $variables['node']->getType() . '.' . $view_mode);
 
   // Use the default display if no display is defined for the view mode.
   if (!$display) {
-    $display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $content_type . '.default');
+    $display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $variables['node']->getType() . '.default');
     if (!$display) {
       return;
     }
@@ -127,7 +124,7 @@ function psul_rmd_drupal_integration_preprocess_node(array &$variables) {
     return;
   }
 
-  // Add hook to allow others to skip adding RMD data to for a node.
+  // Add hook to allow others to skip adding RMD data to a node.
   $skip_node = FALSE;
   \Drupal::moduleHandler()->alter('psul_rmd_drupal_integration_preprocess_node', $skip_node, $variables['node']);
   if ($skip_node) {
@@ -170,4 +167,34 @@ function psul_rmd_drupal_integration_preprocess_node(array &$variables) {
   if (isset($rmd_fields_displayed['publications'])) {
     $variables['content']['rmd_publications'] = $rmd_data_fetcher->getProfilePublications($username);
   }
+}
+
+/**
+ * Checks if the given entity should have RMD data.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity to check.
+ *
+ * @return string|null
+ *   The username if the entity should have RMD data, or NULL otherwise.
+ */
+function _psul_rmd_drupal_integration_should_have_rmd_data(EntityInterface $entity): ?string {
+  $config = \Drupal::config('psul_rmd_drupal_integration.settings');
+  $content_type = $config->get('attached_content_type');
+  $username_field = $config->get('attached_username_field');
+
+  // Skip if the content type or username field are not set.
+  if (!$content_type || !$username_field) {
+    return NULL;
+  }
+
+  // Skip if the current entity is not the correct content type or does not have
+  // the username field.
+  if (!($entity instanceof FieldableEntityInterface) || $entity->bundle() !== $content_type || !$entity->hasField($username_field)) {
+    return NULL;
+  }
+
+  // Get the username from the entity and return NULL if it is not found.
+  $username = $entity->get($username_field)->getString();
+  return $username ?: NULL;
 }

--- a/psul_rmd_drupal_integration.services.yml
+++ b/psul_rmd_drupal_integration.services.yml
@@ -1,4 +1,10 @@
 services:
+  cache.rmd_data:
+    class: Drupal\Core\Cache\CacheBackendInterface
+    tags:
+      - { name: cache.bin, default_backend: cache.backend.permanent_database }
+    factory: cache_factory:get
+    arguments: [rmd_data]
   psul_rmd_drupal_integration.fetcher:
     class: Drupal\psul_rmd_drupal_integration\RmdDataFetcher
-    arguments: ['@cache.data', '@http_client', '@config.factory']
+    arguments: ['@cache.rmd_data', '@http_client', '@config.factory']

--- a/src/RmdDataFetcher.php
+++ b/src/RmdDataFetcher.php
@@ -121,7 +121,7 @@ class RmdDataFetcher implements RmdDataFetcherInterface {
 
     $cache_id = "psul_rmd_data:{$endpoint}:{$username}";
     if ($cache = $this->cacheData->get($cache_id)) {
-      $this->data = $cache->data;
+      $this->data[$username] = $cache->data;
       return;
     }
 

--- a/src/RmdDataFetcher.php
+++ b/src/RmdDataFetcher.php
@@ -59,7 +59,7 @@ class RmdDataFetcher implements RmdDataFetcherInterface {
    * {@inheritdoc}
    */
   public function addCacheTags(array $tags): void {
-    $this->cacheTags = array_merge($tags, $this->cacheTags);
+    $this->cacheTags = array_merge($tags, ['rmd_data']);
   }
 
   /**
@@ -84,6 +84,7 @@ class RmdDataFetcher implements RmdDataFetcherInterface {
    * {@inheritdoc}
    */
   public function getProfilePublications(string $username): array {
+    $this->addCacheTags(['rmd_data:profile:' . $username]);
     $this->fetchUserData($username);
 
     $data = $this->data[$username] ?? [];

--- a/src/RmdDataFetcher.php
+++ b/src/RmdDataFetcher.php
@@ -140,7 +140,7 @@ class RmdDataFetcher implements RmdDataFetcherInterface {
       $this->cacheData->set(
         $cache_id,
         $data,
-        time() + $config->get('cache_ttl') ?? 172800,
+        time() + $config->get('cache_ttl') ?? 86400,
         $this->cacheTags,
       );
 
@@ -151,7 +151,7 @@ class RmdDataFetcher implements RmdDataFetcherInterface {
         $this->cacheData->set(
           $cache_id,
           ['data' => []],
-          time() + $config->get('cache_ttl') ?? 172800,
+          time() + $config->get('cache_ttl') ?? 86400,
           $this->cacheTags,
         );
         return;


### PR DESCRIPTION
Some significant underlying changes to the module.  From the front end you should not see any visual changes but you will see a new database created that store the rmd data (`cache_rmd_data`).  This should be update when the cache is cleared (`ddev drush cr`).  See README for how to clear this data.

## Changes
- Adding pcb module make the API data cache more resilient (i.e. it wont go away with a cache clear) 
  - Clearing rmd cache on node save
  - Adding some documentation
- Follow up to #28. To handle pcb changes and pass $data from the fetchUserData method since storing the data in a class could cause memory issues during cron or batch jobs. 
- Purge cacheTags after the cache is saved so that the wrong tags don't get assigned to other rmd_data profiles.
- Refactoring some code to reuse logic (in .module) file.