### PR TITLE
Issue #18 - User ServiceProvider class to remove cache service so we …

### DIFF
--- a/src/PsulRmdDrupalIntegrationServiceProvider.php
+++ b/src/PsulRmdDrupalIntegrationServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\psul_rmd_drupal_integration;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Class RmdDataServiceProvider.
+ *
+ * @package Drupal\psul_rmd_drupal_integration
+ */
+class PsulRmdDrupalIntegrationServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    try {
+      $container->getDefinition('cache.backend.permanent_database');
+    }
+    catch (ServiceNotFoundException $exception) {
+      // The cache.rmd_data service depends on the pcb cache backend,
+      // since this might not exist for the updates from beta2
+      // we remove the service so that the update hook can run.
+      $container->removeDefinition('cache.rmd_data');
+    }
+  }
+
+}


### PR DESCRIPTION
…can install the pcb module.

The update hook would not run to install the pcb module because the services are loaded before the hook runs.  We need to the use a ServiceProvider to remove the rmd_cache service if the pcb cache service is not available.  This should only be an issue until `psul_rmd_drupal_integration_update_10001()` runs and the `pcb` module is installed. 

See https://www.drupal.org/docs/drupal-apis/services-and-dependency-injection/altering-existing-services-providing-dynamic-services